### PR TITLE
Use google calendar

### DIFF
--- a/appletonmakerspaceweeklycalendar.py
+++ b/appletonmakerspaceweeklycalendar.py
@@ -1,3 +1,19 @@
+"""
+Copyright (c) 2015 Mike Putnam <mike@theputnams.net>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+"""
+
 from __future__ import print_function
 import httplib2
 
@@ -12,7 +28,7 @@ import dateutil.parser
 class AppletonMakerspaceWeeklyCalendar():
     """
     Creates a Google Calendar API service object and outputs a list of the next
-    7 days of events on the user's calendar.
+    weeks events on the user's calendar.
     """
     def __init__(self, service_account_name, path_to_key):
         self.service_account_name = service_account_name
@@ -38,10 +54,9 @@ class AppletonMakerspaceWeeklyCalendar():
         http = credentials.authorize(httplib2.Http())
         service = discovery.build('calendar', 'v3', http=http)
 
-        #now_date = datetime.datetime.utcnow()
-        now_date = datetime.datetime.now()#FIXME
+        now_date = datetime.datetime.utcnow()
         start_lookahead_date = now_date.isoformat() + 'Z' # 'Z' indicates UTC time
-        end_lookahead_date = (now_date + datetime.timedelta(days=7)).isoformat() + 'Z'
+        end_lookahead_date = (now_date + datetime.timedelta(weeks=1)).isoformat() + 'Z'
 
         eventsResult = service.events().list(
             calendarId='appletonmakerspace@gmail.com', #this is the calendar shared to the service account

--- a/appletonmakerspaceweeklycalendar.py
+++ b/appletonmakerspaceweeklycalendar.py
@@ -1,0 +1,65 @@
+from __future__ import print_function
+import httplib2
+
+from googleapiclient import discovery
+
+from oauth2client.client import SignedJwtAssertionCredentials
+
+import datetime
+from datetime import timedelta
+import dateutil.parser
+
+class AppletonMakerspaceWeeklyCalendar():
+    """
+    Creates a Google Calendar API service object and outputs a list of the next
+    7 days of events on the user's calendar.
+    """
+    def __init__(self, service_account_name, path_to_key):
+        self.service_account_name = service_account_name
+        self.path_to_key = path_to_key
+
+    def fetch_events(self):
+        f = file(self.path_to_key, 'rb')
+        key = f.read()
+        f.close()
+
+        # Note that the first parameter to SignedJwtAssertionCredentials, service_account_name,
+        # is the Email address created for the Service account. It must be the email
+        # address associated with the key that was created.
+
+        #https://console.developers.google.com/apis/credentials?project=appletonmakerspace-1075
+
+        credentials = SignedJwtAssertionCredentials(
+            #you need to share access to the calendar to this user from the dev console:
+            self.service_account_name,
+            key,
+            scope='https://www.googleapis.com/auth/calendar.readonly')
+
+        http = credentials.authorize(httplib2.Http())
+        service = discovery.build('calendar', 'v3', http=http)
+
+        #now_date = datetime.datetime.utcnow()
+        now_date = datetime.datetime.now()#FIXME
+        start_lookahead_date = now_date.isoformat() + 'Z' # 'Z' indicates UTC time
+        end_lookahead_date = (now_date + datetime.timedelta(days=7)).isoformat() + 'Z'
+
+        eventsResult = service.events().list(
+            calendarId='appletonmakerspace@gmail.com', #this is the calendar shared to the service account
+            timeMin=start_lookahead_date,
+            timeMax=end_lookahead_date,
+            singleEvents=True,
+            orderBy='startTime'
+        ).execute()
+        events = eventsResult.get('items', [])
+
+        result = ''
+
+        if not events:
+            pass
+        for event in events:
+            start = dateutil.parser.parse(event['start'].get('dateTime', event['start'].get('date')))
+            end = dateutil.parser.parse(event['end'].get('dateTime', event['end'].get('date')))
+            result += '- ' + event['summary'] + '! ' + start.strftime("%A %-I:%M%p") + '-' + end.strftime("%-I:%M%p") + '\n\n'
+
+        return result
+

--- a/emaildhmn.py
+++ b/emaildhmn.py
@@ -81,28 +81,7 @@ def getAttachment(attachmentFilePath):
   attachment.add_header('Content-Disposition', 'attachment',   filename=os.path.basename(attachmentFilePath))
   return attachment
 
-hackmakes = """
-- Open Make Session! Thursday 6:00pm-10:00pm
-"""
-
-newlugmeeting = """
-- NEWLUG Linux Users Group Meeting! Tuesday 6:30pm-9:00pm
-"""
-
-orgmeeting = """
-- Open Organizational Meeting! Monday 8:00pm
-"""
-
-codercooperative = """
-- Coder Cooperative! Monday 7:00pm-9:00pm http://appletonmakerspace.org/codercooperative
-"""
-
-makethespace = """
-- Make the Space night! Monday 6:00pm
-"""
-
 footer = """
-
 --
 
 Want a place to track your project, or look at what others are working on?  Check out the Trello Project Board!
@@ -124,18 +103,21 @@ Reply to this email with a brief run-down of whatever projects have been keeping
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser(description='Send weekly events to dhmn-discuss.')
-    parser.add_argument('-u', '--user')
-    parser.add_argument('-p', '--password')
+    parser.add_argument('--user',help='Gmail user.')
+    parser.add_argument('--password',help='Gmail password.')
+    parser.add_argument('--service_account_name',help='Google Calendar API Service Account name')
+    parser.add_argument('--path_to_key',help='Path to Google Calendar API private key')
     parser.add_argument('recipient')
     args = parser.parse_args()
 
     import datetime
     d = datetime.date.today()
     datestring = '{0:04d}-{1:02d}-{2:02d}'.format(d.year, d.month, d.day)
-    mon = d.day #cron runs every monday
-    fri = (d + datetime.timedelta(days=4)).day
-    this_week_email_body = ""
-    if mon > 7  and mon < 15: this_week_email_body += newlugmeeting #2nd week
-    if mon > 21 and mon < 29: this_week_email_body += orgmeeting #4th week
-    sendMail(args.user,args.password,args.recipient,"This Week at the Appleton Makerspace",this_week_email_body + makethespace + hackmakes + codercooperative + footer) # every week
+
+    from appletonmakerspaceweeklycalendar import AppletonMakerspaceWeeklyCalendar
+    calendar = AppletonMakerspaceWeeklyCalendar(args.service_account_name, args.path_to_key)
+
+    this_week_email_body = calendar.fetch_events()
+    sendMail(args.user,args.password,args.recipient,"This Week at the Appleton Makerspace",this_week_email_body + footer) # every week
     sendMail(args.user,args.password,args.recipient,"What Have You Been Hacking/Making? ["+datestring+" edition]",projects) #every week
+


### PR DESCRIPTION
This is already implemented on the host that runs www.appletonmakerspace.org.

Current front-end calendaring access appears to be delegated to @shanemgrey and Jakob B.

Now the same calendar that we maintain for the website is also the origin of the events in the weekly "This week..." email.

Configuration exists:
- behind the "Sharing" settings in the Google Account Calendar for the appletonmakerspace at gmail user 
- locally on the host 
- on the Google API Console for the appletonmakerspace at gmail user - Calendar API enabled - daily quota 1 million requests. https://console.developers.google.com/apis
